### PR TITLE
Add missing public initializer for SPPerspectiveShadowConfig

### DIFF
--- a/Sources/SPPerspective/Configs/SPPerspectiveShadowConfig.swift
+++ b/Sources/SPPerspective/Configs/SPPerspectiveShadowConfig.swift
@@ -73,4 +73,24 @@ public struct SPPerspectiveShadowConfig {
     public var startCornerVerticalMedian: CGFloat {
         return cornerVerticalOffset - (cornerVerticalOffset - startVerticalOffset) / 2
     }
+
+    /**
+    Create a new SPPerspectiveShadowConfig
+    - parameter blurRadius: Blur radius of the shadow
+     - parameter opacity: Shadow opacity
+     - parameter color: Shadow color
+     - parameter maximumHorizontalOffset: Maximum value for horizontal shadow offset
+     - parameter startVerticalOffset: Initial vertical offset
+     - parameter cornerVerticalOffset: Vertical offset for side (should be smaller than `maximumHorizontalOffset`
+     - parameter maximumVerticalOffset: Maximum value for vertical offset when card is up side down
+    */
+    public init(blurRadius: CGFloat, opacity: CGFloat, color: UIColor, maximumHorizontalOffset: CGFloat, startVerticalOffset: CGFloat, cornerVerticalOffset: CGFloat, maximumVerticalOffset: CGFloat) {
+        self.blurRadius = blurRadius
+        self.opacity = opacity
+        self.color = color
+        self.maximumHorizontalOffset = maximumHorizontalOffset
+        self.startVerticalOffset = startVerticalOffset
+        self.cornerVerticalOffset = cornerVerticalOffset
+        self.maximumVerticalOffset = maximumVerticalOffset
+    }
 }


### PR DESCRIPTION
## Goal
Add public initializer to SPPerspectiveShadowConfig because currently is is impossible to create a custom configuration for the shadow since the initializer is not exposed publicly and thus leads to an error ('SPPerspectiveShadowConfig' is inaccessible due to 'internal' protection level). That is because Swift does not expose the auto-generated member-wise initializer for structs.

**Source:**
> As with the default initializer above, if you want a public structure type to be initializable with a memberwise initializer when used in another module, you must provide a public memberwise initializer yourself as part of the type’s definition.

From: [Swift.org](https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html)
